### PR TITLE
Load MainListeners, LifecycleStrategies and StartupListeners using ServiceLoaders

### DIFF
--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultCamelContextTest.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/DefaultCamelContextTest.java
@@ -16,11 +16,18 @@
  */
 package org.apache.camel.impl.engine;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.Component;
@@ -41,14 +48,6 @@ import org.apache.camel.support.DefaultUuidGenerator;
 import org.apache.camel.support.service.ServiceSupport;
 import org.apache.camel.util.URISupport;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultCamelContextTest extends TestSupport {
 
@@ -437,6 +436,24 @@ public class DefaultCamelContextTest extends TestSupport {
             assertNotNull(oldEndpoint);
         }
 
+    }
+
+    @Test
+    public void testLoadStartupListenerWithServiceLoader() {
+        DefaultCamelContext ctx = new DefaultCamelContext(false);
+
+        assertNotNull(
+            ctx.getStartupListeners().stream().filter(FooStartupListener.class::isInstance).findAny()
+                .orElse(null), FooStartupListener.class.getSimpleName() + " not loaded via SPI.");
+    }
+
+    @Test
+    public void testLoadLifecycleStrategyWithServiceLoader() {
+        DefaultCamelContext ctx = new DefaultCamelContext(false);
+
+        assertNotNull(
+            ctx.getLifecycleStrategies().stream().filter(FooLifecycleStrategy.class::isInstance).findAny()
+                .orElse(null), FooLifecycleStrategy.class.getSimpleName() + " not loaded via SPI.");
     }
 
     private static class MyService extends ServiceSupport implements CamelContextAware {

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/FooLifecycleStrategy.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/FooLifecycleStrategy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.engine;
+
+import org.apache.camel.support.LifecycleStrategySupport;
+
+public class FooLifecycleStrategy extends LifecycleStrategySupport {
+}

--- a/core/camel-core/src/test/java/org/apache/camel/impl/engine/FooStartupListener.java
+++ b/core/camel-core/src/test/java/org/apache/camel/impl/engine/FooStartupListener.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.impl.engine;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.StartupListener;
+
+public class FooStartupListener implements StartupListener {
+
+  @Override
+  public void onCamelContextStarted(CamelContext context, boolean alreadyStarted) {
+  }
+}

--- a/core/camel-core/src/test/resources/META-INF/services/org.apache.camel.StartupListener
+++ b/core/camel-core/src/test/resources/META-INF/services/org.apache.camel.StartupListener
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+org.apache.camel.impl.engine.FooStartupListener

--- a/core/camel-core/src/test/resources/META-INF/services/org.apache.camel.spi.LifecycleStrategy
+++ b/core/camel-core/src/test/resources/META-INF/services/org.apache.camel.spi.LifecycleStrategy
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+org.apache.camel.impl.engine.FooLifecycleStrategy

--- a/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
+++ b/core/camel-main/src/main/java/org/apache/camel/main/BaseMainSupport.java
@@ -36,6 +36,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -116,6 +118,7 @@ import org.apache.camel.vault.VaultConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.stream.Collectors.toCollection;
 import static org.apache.camel.main.MainConstants.profilePropertyPlaceholderLocation;
 import static org.apache.camel.main.MainHelper.computeProperties;
 import static org.apache.camel.main.MainHelper.optionKey;
@@ -140,7 +143,8 @@ public abstract class BaseMainSupport extends BaseService {
             "camel.devConsole.", "camel.variable.", "camel.beans.", "camel.globalOptions.",
             "camel.server.", "camel.ssl.", "camel.debug.", "camel.trace.", "camel.routeController." };
 
-    protected final List<MainListener> listeners = new ArrayList<>();
+    protected final List<MainListener> listeners = ServiceLoader.load(MainListener.class).stream()
+        .map(Provider::get).collect(toCollection(ArrayList::new));
     protected volatile CamelContext camelContext;
     protected final MainConfigurationProperties mainConfigurationProperties = new MainConfigurationProperties();
     protected final OrderedLocationProperties wildcardProperties = new OrderedLocationProperties();

--- a/core/camel-main/src/test/java/org/apache/camel/main/FooMainListener.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/FooMainListener.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.main;
+
+public class FooMainListener extends MainListenerSupport {
+}

--- a/core/camel-main/src/test/java/org/apache/camel/main/MainListenerTest.java
+++ b/core/camel-main/src/test/java/org/apache/camel/main/MainListenerTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.camel.main;
 
+import static org.apache.camel.util.CollectionHelper.propertiesOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import static org.apache.camel.util.CollectionHelper.propertiesOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class MainListenerTest {
 
@@ -93,4 +93,15 @@ public class MainListenerTest {
         }
     }
 
+    @Test
+    public void testLoadMainListenerWithServiceLoader() {
+      Main main = new Main();
+      try {
+        Assertions.assertNotNull(
+            main.getMainListeners().stream().filter(FooMainListener.class::isInstance).findAny()
+                .orElse(null), FooMainListener.class.getSimpleName() + " not loaded via SPI.");
+      } finally {
+        main.stop();
+      }
+    }
 }

--- a/core/camel-main/src/test/resources/META-INF/services/org.apache.camel.main.MainListener
+++ b/core/camel-main/src/test/resources/META-INF/services/org.apache.camel.main.MainListener
@@ -1,0 +1,17 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+org.apache.camel.main.FooMainListener


### PR DESCRIPTION
Currently, there it is not possible to inject custom MainListeners, LifecycleStrategies and StartupListeners in a transparent manner. For MainListeners there is a system property "camel.main.mainListenerClasses" but for other listeners there is none. It seems reasonable to use ServiceLoader for this purpose.