### PR TITLE
Load all classpath property resources instead of the first found

### DIFF
--- a/core/camel-base/src/main/java/org/apache/camel/component/properties/ClasspathPropertiesSource.java
+++ b/core/camel-base/src/main/java/org/apache/camel/component/properties/ClasspathPropertiesSource.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URL;
+import java.util.Enumeration;
 import java.util.Properties;
 
 import org.apache.camel.Ordered;
@@ -49,31 +51,38 @@ public class ClasspathPropertiesSource extends AbstractLocationPropertiesSource 
 
     @Override
     public Properties loadPropertiesFromLocation(PropertiesComponent propertiesComponent, PropertiesLocation location) {
-        Properties answer = new OrderedProperties();
-        String path = location.getPath();
+      Properties answer = new OrderedProperties();
+      String path = location.getPath();
 
-        InputStream is = propertiesComponent.getCamelContext().getClassResolver().loadResourceAsStream(path);
-        Reader reader = null;
-        if (is == null) {
+      Enumeration<URL> resources = propertiesComponent.getCamelContext().getClassResolver().loadResourcesAsURL(path);
+      while (resources.hasMoreElements()) {
+        URL resource = resources.nextElement();
+        try (InputStream is = resource.openStream()) {
+          Reader reader = null;
+          if (is == null) {
             if (!propertiesComponent.isIgnoreMissingLocation() && !location.isOptional()) {
-                throw RuntimeCamelException.wrapRuntimeCamelException(
-                        new FileNotFoundException("Properties file " + path + " not found in classpath"));
+              throw RuntimeCamelException.wrapRuntimeCamelException(
+                  new FileNotFoundException("Properties file " + path + " not found in classpath"));
             }
-        } else {
+          } else {
             try {
-                if (propertiesComponent.getEncoding() != null) {
-                    reader = new BufferedReader(new InputStreamReader(is, propertiesComponent.getEncoding()));
-                    answer.load(reader);
-                } else {
-                    answer.load(is);
-                }
+              if (propertiesComponent.getEncoding() != null) {
+                reader = new BufferedReader(new InputStreamReader(is, propertiesComponent.getEncoding()));
+                answer.load(reader);
+              } else {
+                answer.load(is);
+              }
             } catch (IOException e) {
-                throw RuntimeCamelException.wrapRuntimeCamelException(e);
+              throw RuntimeCamelException.wrapRuntimeCamelException(e);
             } finally {
-                IOHelper.close(reader, is);
+              IOHelper.close(reader, is);
             }
+          }
+        } catch (IOException e) {
+          throw RuntimeCamelException.wrapRuntimeCamelException(e);
         }
-        return answer;
+      }
+      return answer;
     }
 
     @Override


### PR DESCRIPTION

Currently, when there are two property files with the same name on the classpath (e.g. application.properties), Camel only loads the first one. This change ensures that all files are loaded.

<!--
- Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
-->

# Target

- [x] I checked that the commit is targeting the correct branch (Camel 4 uses the `main` branch)

# Tracking
- [x] If this is a large change, bug fix, or code improvement, I checked there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).

<!--
# *Note*: trivial changes like, typos, minor documentation fixes and other small items do not require a JIRA issue. In this case your pull request should address just this issue, without pulling in other changes.
-->

# Apache Camel coding standards and style

- [x] I checked that each commit in the pull request has a meaningful subject line and body.

<!--
If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
-->

- [x] I have run `mvn clean install -DskipTests` locally from root folder and I have committed all auto-generated changes.

<!--
You can run the aforementioned command in your module so that the build auto-formats your code. This will also be verified as part of the checks and your PR may be rejected if if there are uncommited changes after running `mvn clean install -DskipTests`.

You can learn more about the contribution guidelines at https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

